### PR TITLE
Minor changes to CMakeLists and manifests to run on Indigo on 14.04

### DIFF
--- a/ndt_costmap/package.xml
+++ b/ndt_costmap/package.xml
@@ -46,7 +46,7 @@
   <build_depend>opencv2</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
-
+  <build_depend>cmake_modules</build_depend>
   <run_depend>ndt_map</run_depend>
   <run_depend>opencv2</run_depend>
   <run_depend>eigen</run_depend>

--- a/ndt_feature_reg/CMakeLists.txt
+++ b/ndt_feature_reg/CMakeLists.txt
@@ -10,13 +10,13 @@ catkin_package(
     LIBRARIES ${PROJECT_NAME}
 )
 
-
+set(OpenCV_DIR "/home/icoderaven/packages/opencv-2.4.9/release")
 find_package(OpenCV REQUIRED)
 include_directories(${catkin_INCLUDE_DIRS})
 ADD_DEFINITIONS(-DLINUX_OS)
 include_directories(include)
 include_directories(${OpenCV_INCLUDE_DIRS})
-
+message(STATUS "OPENCV INCLUDES!!!!! "${OpenCV_INCLUDE_DIRS})
 find_package(VTK REQUIRED)
 
 

--- a/ndt_feature_reg/CMakeLists.txt
+++ b/ndt_feature_reg/CMakeLists.txt
@@ -9,14 +9,13 @@ catkin_package(
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
 )
-
-set(OpenCV_DIR "/home/icoderaven/packages/opencv-2.4.9/release")
+#Pull the location of the locally installed OpenCV directory, if defined in the environment 
+set(OpenCV_DIR $ENV{OpenCV_DIR})
 find_package(OpenCV REQUIRED)
 include_directories(${catkin_INCLUDE_DIRS})
 ADD_DEFINITIONS(-DLINUX_OS)
 include_directories(include)
 include_directories(${OpenCV_INCLUDE_DIRS})
-message(STATUS "OPENCV INCLUDES!!!!! "${OpenCV_INCLUDE_DIRS})
 find_package(VTK REQUIRED)
 
 

--- a/ndt_feature_reg/package.xml
+++ b/ndt_feature_reg/package.xml
@@ -31,7 +31,7 @@
   <build_depend>image_transport</build_depend>
   <!--build_depend>opencv2</build_depend-->
   <build_depend>cv_bridge</build_depend>
-
+  <build_depend>cmake_modules</build_depend>
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>ndt_registration</run_depend>
   <run_depend>ndt_map</run_depend>

--- a/ndt_fuser/package.xml
+++ b/ndt_fuser/package.xml
@@ -38,6 +38,7 @@
   <run_depend>visualization_msgs</run_depend>
   <run_depend>libpcl-all-dev</run_depend>
   <run_depend>message_runtime</run_depend>
+  <build_depend>cmake_modules</build_depend>
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>ndt_registration</test_depend> -->
   <!-- <test_depend>ndt_map</test_depend> -->

--- a/ndt_map/CMakeLists.txt
+++ b/ndt_map/CMakeLists.txt
@@ -5,7 +5,9 @@ cmake_minimum_required(VERSION 2.8.3)
 set(CMAKE_BUILD_TYPE Release) 
 project(ndt_map)
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS cv_bridge eigen roscpp pcl_ros pcl_conversions 
+find_package(cmake_modules REQUIRED)
+find_package(Eigen REQUIRED)
+find_package(catkin REQUIRED COMPONENTS cv_bridge roscpp pcl_ros pcl_conversions 
   std_msgs
   nav_msgs
    message_generation  )

--- a/ndt_map/package.xml
+++ b/ndt_map/package.xml
@@ -30,7 +30,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>nav_msgs</build_depend>
-
+  <build_depend>cmake_modules</build_depend>
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>libpcl-all</run_depend>
   <run_depend>roscpp</run_depend>

--- a/ndt_map_builder/package.xml
+++ b/ndt_map_builder/package.xml
@@ -32,7 +32,7 @@
   <run_depend>pcl_conversions</run_depend>
   <run_depend>ndt_map</run_depend>
   <run_depend>ndt_registration</run_depend>
-
+  <build_depend>cmake_modules</build_depend>
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>common_rosdeps</test_depend> -->
   <!-- <test_depend>pcl</test_depend> -->

--- a/ndt_mcl/CMakeLists.txt
+++ b/ndt_mcl/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8.3)
 set(CMAKE_BUILD_TYPE Release) 
 project(ndt_mcl)
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS ndt_visualisation rosbag tf nav_msgs sensor_msgs geometry_msgs message_filters ndt_map ndt_registration visualization_msgs)
+find_package(catkin REQUIRED COMPONENTS ndt_visualisation rosbag tf nav_msgs sensor_msgs geometry_msgs message_filters ndt_map ndt_registration visualization_msgs cmake_modules)
 
 catkin_package(
     DEPENDS libpcl-all-dev eigen mrpt
@@ -14,8 +14,8 @@ catkin_package(
 )
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-#find_package(Eigen REQUIRED)
-#include_directories(${EIGEN_INCLUDE_DIRS})
+find_package(Eigen REQUIRED)
+include_directories(${EIGEN_INCLUDE_DIRS})
 add_definitions(${EIGEN_DEFINITIONS})
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)

--- a/ndt_mcl/package.xml
+++ b/ndt_mcl/package.xml
@@ -32,6 +32,7 @@
   <build_depend>mrpt</build_depend>
   <build_depend>glut</build_depend>
   <build_depend>libxmu-dev</build_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>ndt_visualisation</run_depend>

--- a/ndt_registration/package.xml
+++ b/ndt_registration/package.xml
@@ -27,7 +27,7 @@
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
-
+  <build_depend>cmake_modules</build_depend>
   <!-- Dependencies needed after this package is compiled. -->
   <!--<run_depend>common_rosdeps</run_depend>-->
   <run_depend>ndt_map</run_depend>

--- a/ndt_rviz_visualisation/package.xml
+++ b/ndt_rviz_visualisation/package.xml
@@ -42,7 +42,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rviz</build_depend>
   <run_depend>rviz</run_depend>
-
+  <build_depend>cmake_modules</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/ndt_visualisation/CMakeLists.txt
+++ b/ndt_visualisation/CMakeLists.txt
@@ -4,7 +4,10 @@ cmake_minimum_required(VERSION 2.8.3)
 set(CMAKE_BUILD_TYPE Release) 
 project(ndt_visualisation)
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS ndt_map pcl_ros eigen)
+find_package(cmake_modules REQUIRED)
+find_package(Eigen REQUIRED)
+
+find_package(catkin REQUIRED COMPONENTS ndt_map pcl_ros)
 catkin_package(
     DEPENDS libpcl-all-dev eigen glut opengl#libxmu-dev mrpt 
     CATKIN_DEPENDS ndt_map pcl_ros message_runtime

--- a/ndt_visualisation/package.xml
+++ b/ndt_visualisation/package.xml
@@ -29,7 +29,7 @@
   <!--build_depend>freeglut3-dev</build_depend-->
   <build_depend>libxmu-dev</build_depend>
   <build_depend>libxi-dev</build_depend>
-	
+  <build_depend>cmake_modules</build_depend>	
   <!-- Dependencies needed after this package is compiled. -->
   <!--<run_depend>common_rosdeps</run_depend>-->
   <run_depend>pcl_ros</run_depend>

--- a/perception_oru/package.xml
+++ b/perception_oru/package.xml
@@ -33,6 +33,7 @@
   <run_depend>ndt_map</run_depend>
   <run_depend>ndt_visualisation</run_depend>
   <run_depend>ndt_rviz_visualisation</run_depend>	
+  <build_depend>cmake_modules</build_depend>
   <!-- Dependencies needed only for running tests. -->
  <export> <metapackage/> </export>
 </package>

--- a/sdf_tracker/CMakeLists.txt
+++ b/sdf_tracker/CMakeLists.txt
@@ -6,7 +6,8 @@ project(sdf_tracker)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 
-find_package(catkin REQUIRED COMPONENTS roscpp std_msgs cv_bridge eigen)
+find_package(catkin REQUIRED COMPONENTS roscpp std_msgs cv_bridge cmake_modules)
+find_package(Eigen REQUIRED)
 
 catkin_package(
     DEPENDS eigen opencv2 libvtk

--- a/sdf_tracker/package.xml
+++ b/sdf_tracker/package.xml
@@ -43,6 +43,7 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>opencv2</run_depend>
   <run_depend>libvtk</run_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Added cmake modules as a build dependency, and moved the Eigen library includes as required by hydro->indigo migration

Additionally, something is off with the non-free libraries in OpenCV, so explicitly linked to OpenCV built without OpenCL as suggested in https://github.com/tum-vision/lsd_slam/issues/27
